### PR TITLE
Generate and upload AppImage for each git push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,16 @@ install:
 script:
   - qmake PREFIX=/usr
   - make -j$(nproc)
-  - make INSTALL_ROOT=appdir install ; find appdir/
+  - mkdir -p appdir/usr/bin
+  - mkdir -p appdir/usr/share/{applications,pixmaps}
+  - cp Cumulus appdir/usr/bin/
+  - cp cumulus.svg appdir/usr/share/pixmaps/
+  - echo "[Desktop Entry]" >> appdir/usr/share/applications/cumulus.desktop
+  - echo "Name=Cumulus" >> appdir/usr/share/applications/cumulus.desktop
+  - echo "Icon=cumulus" >> appdir/usr/share/applications/cumulus.desktop
+  - echo "Exec=cumulus" >> appdir/usr/share/applications/cumulus.desktop
+  - echo "Type=Application" >> appdir/usr/share/applications/cumulus.desktop
+  - echo "Categories=Utility;" >> appdir/usr/share/applications/cumulus.desktop
 
 after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt59base qt59declarative qt59svg
+    - sudo apt-get -y install qt59base qt59declarative qt59svg qt59quickcontrols qt59quickcontrols2 
     - source /opt/qt*/bin/qt*-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - echo "[Desktop Entry]" >> appdir/usr/share/applications/cumulus.desktop
   - echo "Name=Cumulus" >> appdir/usr/share/applications/cumulus.desktop
   - echo "Icon=cumulus" >> appdir/usr/share/applications/cumulus.desktop
-  - echo "Exec=cumulus" >> appdir/usr/share/applications/cumulus.desktop
+  - echo "Exec=Cumulus" >> appdir/usr/share/applications/cumulus.desktop
   - echo "Type=Application" >> appdir/usr/share/applications/cumulus.desktop
   - echo "Categories=Utility;" >> appdir/usr/share/applications/cumulus.desktop
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt59base qt59declarative qt59svg qt59quickcontrols qt59quickcontrols2 
+    - sudo apt-get -y install qt59base qt59declarative qt59svg qt59quickcontrols qt59quickcontrols2 qt59graphicaleffects
     - source /opt/qt*/bin/qt*-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - sudo apt-get update -qq
     
 install: 
-    - sudo apt-get -y install qt59base qt59declarative
+    - sudo apt-get -y install qt59base qt59declarative qt59svg
     - source /opt/qt*/bin/qt*-env.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
     - source /opt/qt*/bin/qt*-env.sh
 
 script:
+  - sed -i -e 's|<file>qt/etc/qt.conf</file>||g' qml.qrc # according to README
   - qmake PREFIX=/usr
   - make -j$(nproc)
   - mkdir -p appdir/usr/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+before_install:
+    - sudo add-apt-repository ppa:beineri/opt-qt59-trusty -y
+    - sudo apt-get update -qq
+    
+install: 
+    - sudo apt-get -y install qt59base qt59declarative
+    - source /opt/qt*/bin/qt*-env.sh
+
+script:
+  - qmake PREFIX=/usr
+  - make -j$(nproc)
+  - make INSTALL_ROOT=appdir install ; find appdir/
+
+after_success:
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - curl --upload-file ./Cumulus*.AppImage https://transfer.sh/Cumulus-git.$(git rev-parse --short HEAD)-x86_64.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - mkdir -p appdir/usr/bin
   - mkdir -p appdir/usr/share/{applications,pixmaps}
   - cp Cumulus appdir/usr/bin/
-  - cp cumulus.svg appdir/usr/share/pixmaps/
+  - cp icons/icon.png appdir/usr/share/pixmaps/cumulus.png
   - echo "[Desktop Entry]" >> appdir/usr/share/applications/cumulus.desktop
   - echo "Name=Cumulus" >> appdir/usr/share/applications/cumulus.desktop
   - echo "Icon=cumulus" >> appdir/usr/share/applications/cumulus.desktop

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ after_success:
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage
   - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs
-  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -bundle-non-qt-libs -qmldir=.
+  - ./linuxdeployqt*.AppImage ./appdir/usr/share/applications/*.desktop -appimage -qmldir=.
   - find ./appdir -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
   - curl --upload-file ./Cumulus*.AppImage https://transfer.sh/Cumulus-git.$(git rev-parse --short HEAD)-x86_64.AppImage


### PR DESCRIPTION
This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build (see below for how to set up automatic uploading to your GitHub Releases page).

For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

__Please note:__ Instead of storing AppImage builds temporarily for 14 days each on transfer.sh, you could use GitHub Releases to store the binaries permanently. This way, they would be visible on the Releases page of your project. This is what I recommend. See https://docs.travis-ci.com/user/deployment/releases/. If you want to do this for continuous builds, also see https://github.com/probonopd/uploadtool.

If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.